### PR TITLE
Adds ability to have a proxy only for a given number

### DIFF
--- a/lib/testing/proxy-status.test.js
+++ b/lib/testing/proxy-status.test.js
@@ -20,6 +20,10 @@ describe("Proxy Status", () => {
     consoleErrorSpy.mockClear();
   });
 
+  afterEach(() => {
+    mock.reset()
+  })
+
   test("is a function", () => {
     expect(typeof Proxy.handler).toBe("function");
   });
@@ -84,5 +88,39 @@ describe("Proxy Status", () => {
     return expect(callback.mock.calls[0][0].message).toEqual(
       "Request failed with status code 500"
     );
+  });
+
+  test("will send a copy of inbound body only to destinations that match To:", async () => {
+    const successfulUrl = "https://www.good.com";
+    const successfulDestination = `+12065551212$$${successfulUrl}`;
+
+    const { event, context, callback } = inboundSmsFactory();
+    context.PROXY_STATUS_DESTINATIONS = [successfulDestination].join(",");
+
+    mock
+      .onPost(successfulUrl)
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?><Response/>`);
+
+    await Proxy.handler(context, event, callback);
+
+    expect(mock.history.post.length).toEqual(1)
+    return expect(stringifyPayload(callback.mock.calls[0])).toEqual([
+      null,
+      new twilio.twiml.MessagingResponse().toString(),
+    ]);
+  });
+
+
+  test("will NOT send copy when To: does not match a registered destination", async () => {
+    const successfulUrl = "https://www.good.com";
+    const successfulDestination = `+15408225121$$${successfulUrl}`;
+
+    const { event, context, callback } = inboundSmsFactory();
+    context.PROXY_STATUS_DESTINATIONS = [successfulDestination].join(",");
+
+    mock.onPost(successfulUrl)
+
+    await Proxy.handler(context, event, callback);
+    expect(mock.history.post).toEqual([])
   });
 });

--- a/lib/testing/proxy.test.js
+++ b/lib/testing/proxy.test.js
@@ -5,7 +5,7 @@ const twilio = require("twilio");
 const Proxy = require("../../functions/proxy.protected");
 const { stringifyPayload } = require("./stringifyPayload");
 const inboundSmsFactory = require("./inboundSmsFactory");
-const { before } = require("lodash");
+const { before, after } = require("lodash");
 
 var mock = new MockAdapter(axios);
 let consoleErrorSpy;
@@ -23,6 +23,10 @@ describe("Proxy", () => {
     consoleErrorSpy.mockClear();
     consoleWarnSpy.mockClear();
   });
+
+  afterEach(() => {
+    mock.reset()
+  })
 
   test("is a function", () => {
     expect(typeof Proxy.handler).toBe("function");
@@ -147,5 +151,39 @@ describe("Proxy", () => {
       ]
     );
     return;
+  });
+
+  test("will send a copy of inbound body only to destinations that match To:", async () => {
+    const successfulUrl = "https://www.good.com";
+    const successfulDestination = `+12065551212$$${successfulUrl}`;
+
+    const { event, context, callback } = inboundSmsFactory();
+    context.PROXY_DESTINATIONS = [successfulDestination].join(",");
+
+    mock
+      .onPost(successfulUrl)
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?><Response/>`);
+
+    await Proxy.handler(context, event, callback);
+
+    expect(mock.history.post.length).toEqual(1)
+    return expect(stringifyPayload(callback.mock.calls[0])).toEqual([
+      null,
+      new twilio.twiml.MessagingResponse().toString(),
+    ]);
+  });
+
+
+  test("will NOT send copy when To: does not match a registered destination", async () => {
+    const successfulUrl = "https://www.good.com";
+    const successfulDestination = `+15408225121$$${successfulUrl}`;
+
+    const { event, context, callback } = inboundSmsFactory();
+    context.PROXY_DESTINATIONS = [successfulDestination].join(",");
+
+    mock.onPost(successfulUrl)
+
+    await Proxy.handler(context, event, callback);
+    expect(mock.history.post).toEqual([])
   });
 });


### PR DESCRIPTION
This change adds an ability to have the destinations list have a URL have a phone number. 

Previously the ENV variable was something like 
```https:///www.example.com,https://second-url.com```

This keeps this same pattern but allows a additional comma separated values that are split by `$$`

```<number>$$<url>```

This number must be a E.164 format and must match the "to" message of the twilio payload. 

```+12065551212$$https://api.front....```